### PR TITLE
Avoid to get an extra move when puzzle is incomplete

### DIFF
--- a/modules/puzzle/position_list.py
+++ b/modules/puzzle/position_list.py
@@ -20,7 +20,7 @@ class position_list:
 
     def move_list(self):
         if self.next_position is None or self.next_position.ambiguous() or self.next_position.position.is_game_over():
-            if self.best_move is not None:
+            if self.player_turn and self.best_move is not None:
                 return [self.best_move.bestmove.uci()]
             else:
                 return []


### PR DESCRIPTION
Example(after Ke3 next move is reported as ambiguous, but Ke3 is in the pgn): 
29. Rg1 Ne2+ 30. Kd2 Nxg1 31. Ke3 0-1

We take into account the last move only if it's the player turn. Than we have:
29. Rg1 Ne2+ 30. Kd2 Nxg1 0-1