### PR TITLE
Fix broken ambiguous condition

### DIFF
--- a/modules/puzzle/position_list.py
+++ b/modules/puzzle/position_list.py
@@ -143,10 +143,10 @@ class position_list:
                 if (self.analysed_legals[0].evaluation.mate < 1
                         and self.analysed_legals[1].evaluation.mate < 1):
                     return True
-            if self.analysed_legals[0].evaluation.mate is None or self.analysed_legals[1].evaluation.cp is None:
-                return
-            if self.analysed_legals[1].evaluation.cp < -200:
-                return True
+            if (self.analysed_legals[0].evaluation.mate is not None
+                    and self.analysed_legals[1].evaluation.cp is not None):
+                if self.analysed_legals[1].evaluation.cp < -200:
+                    return True
         return False
 
     def game_over(self):


### PR DESCRIPTION
A bug was introduced in one of the previous PRs.
This one restores proper condition in ambiguous() method.