### PR TITLE
Fix resolving --strict value

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ def prepare_settings():
     parser.add_argument("--games", metavar="GAMES", default="games.pgn",
                         help="A specific pgn with games")
     parser.add_argument("--strict", metavar="STRICT", default=True,
+                        type=str2bool, const=True, nargs="?",
                         help="If False then it will be generate more tactics but maybe a little ambiguous")
     parser.add_argument("--includeBlunder", metavar="INCLUDE_BLUNDER", default=True,
                         type=str2bool, const=True, dest="include_blunder", nargs="?",

--- a/modules/puzzle/position_list.py
+++ b/modules/puzzle/position_list.py
@@ -130,13 +130,14 @@ class position_list:
                 return False
 
     def ambiguous(self):
-        # If strict == False then it will generate more tactics but  more ambiguous
+        # If strict == False then it will generate more tactics but more ambiguous
         move_number = 1 if self.strict else 2
         if len(self.analysed_legals) > 1:
             if (self.analysed_legals[0].evaluation.cp is not None
                     and self.analysed_legals[1].evaluation.cp is not None):
                 if (self.analysed_legals[0].evaluation.cp > -210
-                        or self.analysed_legals[move_number].evaluation.cp < -90):
+                        or (len(self.analysed_legals) >= move_number
+                            and self.analysed_legals[move_number].evaluation.cp < -90)):
                     return True
             if (self.analysed_legals[0].evaluation.mate is not None
                     and self.analysed_legals[1].evaluation.mate is not None):


### PR DESCRIPTION
Fixes #21

Please, note the following lines:
https://github.com/vitogit/pgn-tactics-generator/compare/master...karol-brejna-i:fix-strict?expand=1#diff-e31f1011e582ea3d502823f13a4a64fdef87e41ed47178a0a6e497df1402a27cR139-R140

There were cases where the number of analyzed legals was 2. In that case 
```
self.analysed_legals[move_number].evaluation.cp
```
failed with IndexError

I proposed an addition condition (as above), but don't really know the intent of that piece of code. 